### PR TITLE
create order-form page

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -121,7 +121,7 @@ app.get('/shipping/:id', (req, res) => {
 		FROM shipping_methods
 		INNER JOIN shipping_fees ON shipping_methods.id=shipping_fees.method_id
 		WHERE method_id=${req.params.id}
-		ORDER BY method_id, size`,
+		ORDER BY min_n`,
 	(err, results, fields) => {
 		if (err) {
 			console.log('connection error');
@@ -151,15 +151,11 @@ app.post('/order-process', async (req, res, next) => {
 });
 
 app.post('/create-checkout-session', async (req, res) => {
+	console.log(req.body);
 	const price = 6000; // フロントからcookieを受け取り、カートのデータベースから金額を取得する
+	/*
 	const session = await stripe.checkout.sessions.create({
 		billing_address_collection: 'required',
-		shipping_address_collection: {
-			allowed_countries: ['JP'],
-		},
-		phone_number_collection: {
-			enabled: true,
-		},
 		line_items: [
 			{
 				price_data: {
@@ -176,7 +172,9 @@ app.post('/create-checkout-session', async (req, res) => {
 		success_url: `${FRONTEND_ORIGIN}/order-processing?checkout_session_id={CHECKOUT_SESSION_ID}`,
 		cancel_url: `${FRONTEND_ORIGIN}/order-processing?checkout_session_id={CHECKOUT_SESSION_ID}`,
 	});
-	res.redirect(303, `${session.url}`);
+	*/
+	res.json({status: 'success', order_id: '0123456789'});
+	// res.redirect(303, `${session.url}`);
 });
 
 app.all("*", (req, res) => {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import {
   Cart,
   FAQ,
   OrderCompleted,
+  OrderForm,
   OrderProcessing,
   Product,
   Products,
@@ -24,6 +25,7 @@ const router = createBrowserRouter([
   { path: '/products/:product_id', element: <Product /> },
   { path: '/cart', element: <Cart /> },
   { path: '/faq', element: <FAQ /> },
+  { path: '/order-form', element: <OrderForm />},
   { path: '/order-completed', element: <OrderCompleted />},
   { path: '/order-processing', element: <OrderProcessing />}
 ]);

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -3,7 +3,7 @@ import { React } from 'react';
 const Footer = () => {
 	return (
 		<div className='py-10 bg-stone-800'>
-			<p className='text-center text-white'>© 2023 ひだまり農園</p>
+			<p className='text-center text-white'>&copy; 2023 ひだまり農園</p>
 			<p className='text-center text-white'>
 				<a
 					href='https://chisso06.notion.site/chisso06/Chisso-s-Portfolio-868e0394f3ab4748a01bd5929fa42e0b#310bdc25a6c544bfbc5a679c94a3c70f'

--- a/frontend/src/functions/CreateCart.js
+++ b/frontend/src/functions/CreateCart.js
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+const CreateCart = async (setCart) => {
+	const cartStorage = JSON.parse(localStorage.getItem('cart'));
+	if (cartStorage) {
+		const cartList = await Promise.all(cartStorage.map(async (c) => {
+			const res = await axios.get(`/backend/products/${c.product_id}`)
+				.catch((err) => console.log(err));
+			const item = {
+				product_id: c.product_id,
+				number: c.number,
+				name: res.data.name,
+				price: res.data.price,
+				shipping_method: res.data.shipping_method,
+				image_id: 1
+			};
+			return item;
+		}));
+		setCart(cartList);
+	}
+}
+
+export default CreateCart;

--- a/frontend/src/functions/index.js
+++ b/frontend/src/functions/index.js
@@ -1,0 +1,1 @@
+export { default as CreateCart } from './CreateCart';

--- a/frontend/src/pages/Cart.jsx
+++ b/frontend/src/pages/Cart.jsx
@@ -1,29 +1,11 @@
 import { faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import axios from 'axios';
 import { React, useEffect, useState } from 'react';
+import { CreateCart } from '../functions';
 
 const Cart = () => {
 	var sum = 0;
   const [cart, setCart] = useState([]);
-
-  const CreateCart = async (cartStorage) => {
-		if (cartStorage) {
-			const cartList = await Promise.all(cartStorage.map(async (c) => {
-				const res = await axios.get(`/backend/products/${c.product_id}`)
-					.catch((err) => console(err));
-				const item = {
-					product_id: c.product_id,
-					number: c.number,
-					name: res.data.name,
-					price: res.data.price,
-					image_id: 1
-				};
-				return item;
-			}));
-			setCart(cartList);
-		}
-  }
 
 	const handleChange = (e, i) => {
 		var value = Number(e.target.value);
@@ -33,7 +15,7 @@ const Cart = () => {
 			value = 0;
 		cartStorage[i].number = value;
 		localStorage.setItem('cart', JSON.stringify(cartStorage));
-		CreateCart(cartStorage);
+		CreateCart(setCart);
 	}
 
 	const handleTrash = (i) => {
@@ -41,13 +23,11 @@ const Cart = () => {
 
 		cartStorage.splice(i, 1);
 		localStorage.setItem('cart', JSON.stringify(cartStorage));
-		CreateCart(cartStorage);
+		CreateCart(setCart);
 	}
 
 	useEffect(() => {
-		const cartStorage = JSON.parse(localStorage.getItem('cart'));
-
-		CreateCart(cartStorage);
+		CreateCart(setCart);
 	}, []);
 
 	return (
@@ -95,15 +75,15 @@ const Cart = () => {
 							</div>
 						);
 					})}
-					<form action='/backend/create-checkout-session' method='POST' className='w-60 mx-auto my-10'>
+					<div className='w-60 mx-auto my-10'>
 						<p className='mt-10 text-center text-2xl sm:text-3xl font-mono font-bold'>
-							合計：{sum}円
+							小計：{sum}円
 						</p>
 						<p className='pt-4 mb-8 text-center text-sm text-stone-600'>※送料は購入手続き時に計算されます</p>
-						<button type='submit' className='w-60 p-2 text-white bg-amber-600 hover:bg-amber-500 rounded'>
+						<a href='/order-form' className='w-60 p-2 inline-block text-center text-white bg-amber-600 hover:bg-amber-500 rounded'>
 							お支払いにすすむ
-						</button>
-					</form>
+						</a>
+					</div>
 				</div>
 				: <p className='my-48 text-center'>現在、カートに入っている商品はありません。</p>
 			}

--- a/frontend/src/pages/OrderForm.jsx
+++ b/frontend/src/pages/OrderForm.jsx
@@ -1,0 +1,241 @@
+import axios from 'axios';
+import { React, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { CreateCart } from '../functions';
+
+const OrderForm = () => {
+	const [sum, setSum] = useState(0);
+	const [shippingMethods, setShippingMethods] = useState([]);
+	const [shippingFee, setShippingFee] = useState(0);
+	const [cart, setCart] = useState([{}]);
+	const [customerData, setCustomerData] = useState({
+		email: '',
+		phone: '',
+		name: '',
+		zipCode: '',
+		prefecture: '',
+		address: '',
+    memo: ''
+	});
+	// const [customerData, setCustomerData] = useState({
+	// 	email: 'tkgth0725@gmail.com',
+	// 	phone: '09032824468',
+	// 	name: '鈴木美優',
+	// 	zipCode: '6310003',
+	// 	prefecture: '奈良県',
+	// 	address: '奈良市中登美ヶ丘4-1-2-103',
+  //   memo: '特になし'
+	// });
+	const navigate = useNavigate();
+
+	const handleChange = (e) => {
+		setCustomerData({...customerData, [e.target.name]: e.target.value});
+	};
+
+	const handleAreaChange = async (e) => {
+		const areaList = [
+			{method_name: 'Hokkaido', name: '北海道', prefectures: ['北海道']},
+			{method_name: 'Hokkaido', name: '東北', prefectures: ['青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県']},
+			{method_name: 'Hokkaido', name: '関東', prefectures: ['茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県', '山梨県']},
+			{method_name: 'Hokkaido', name: '信越', prefectures: ['新潟県', '長野県']},
+			{method_name: 'Hokkaido', name: '北陸', prefectures: ['富山県', '石川県', '福井県']},
+			{method_name: 'Hokkaido', name: '東海', prefectures: ['岐阜県', '静岡県', '愛知県', '三重県']},
+			{method_name: 'Hokkaido', name: '近畿', prefectures: ['滋賀県', '京都府', '大阪府', '兵庫県', '奈良県', '和歌山県']},
+			{method_name: 'Hokkaido', name: '中国', prefectures: ['鳥取県', '島根県', '岡山県', '広島県', '山口県']},
+			{method_name: 'Hokkaido', name: '四国', prefectures: ['徳島県', '香川県', '愛媛県', '高知県']},
+			{method_name: 'Hokkaido', name: '九州', prefectures: ['福岡県', '佐賀県', '長崎県', '熊本県', '大分県', '宮崎県', '鹿児島県']},
+			{method_name: 'Hokkaido', name: '沖縄', prefectures: ['沖縄県']},
+		];
+		var shippingFeeCalc = 0;
+
+		setCustomerData({...customerData, 'prefecture': e.target.value});
+		await Promise.all(shippingMethods.map(async (method) => {
+			await axios.get(`/backend/shipping/${method.method_id}`)
+				.then((res) => {
+					var i = 0;
+					while (i < res.data.length - 1 && (method.number < res.data[i].min_n || res.data[i].max_n < method.number))
+						i ++;
+					const area = areaList.find((area) => area.prefectures.find((p) => p === e.target.value));
+					shippingFeeCalc += res.data[i][area.method_name];
+				})
+				.catch((err) => console.log(err));
+		}))
+		setShippingFee(shippingFeeCalc);
+	};
+
+	useEffect(() => {
+		CreateCart(setCart);
+	}, []);
+
+	useEffect(() => {
+		if (cart.length && Object.keys(cart[0]).length) {
+			var sum_calc = 0;
+			const shippingMethodList = [];
+
+			cart.map((item) => {
+				const i = shippingMethodList.findIndex(
+					({method_id}) => method_id === item.shipping_method);
+				if (i < 0)
+					shippingMethodList.push({method_id: item.shipping_method, number: item.number});
+				else
+					shippingMethodList[i].number += item.number;
+				sum_calc += item.price * item.number;
+				return item;
+			})
+			setSum(sum_calc);
+			setShippingMethods(shippingMethodList);
+		}
+	}, [cart]);
+
+	useEffect(() => {
+		if (!cart.length)
+			navigate('/cart');
+	}, [cart.length, navigate]);
+
+	return (
+		<div className='mt-32 mb-10 sm:mt-40 sm:mb-20'>
+			<div className='w-3/4 mx-auto sm:flex sm:gap-2'>
+				<div className='w-full sm:w-2/5 mb-10'>
+					<div className='p-2 border rounded'>
+						<a href='/cart'>&lt; <span className='text-sm hover:underline'>買い物かごに戻る</span></a>
+						<ul className='p-2 font-mono'>{
+							cart.length && Object.keys(cart[0]).length ? cart.map((item, i) => {
+								return (<li key={i} className='pr-2 py-4 flex border-b'>
+									<img
+										src={'/products/' + item.image_id + '.jpg'}
+										alt='商品画像'
+										className='w-16 h-16 aspect-square object-cover rounded' />
+									<div className='w-full pl-4 items-center'>
+										<a
+											href={'/products/' + item.product_id}
+											className='h-full hover:underline'>
+											{item.name}
+										</a>
+										<div className='h-full flex justify-end items-center'>
+											<p className='h-full font-bold'>
+												¥{item.price}
+												<span className='text-stone-400 font-normal text-base'>/個</span>
+												<span className='mx-1 h-full text-base font-normal items-center text-center'>
+													×{item.number}
+												</span>
+											</p>
+										</div>
+									</div>
+								</li>);
+							}) : ''
+						}</ul>
+						<div className='mt-6 px-2 font-mono'>
+							<div className='flex'>
+								<p className='w-full'>小計</p>
+								<p className='w-full text-right'>¥{sum}</p>
+							</div>
+							<div className='flex'>
+								<p className='w-full'>送料</p>
+								<p className='w-full text-right'>¥{shippingFee}</p>
+							</div>
+							<div className='mt-2 pt-2 flex border-stone-700 border-t'>
+								<p className='w-full text-xl font-bold'>合計</p>
+								<p className='w-full text-xl font-bold text-right'>¥{sum + shippingFee}</p>
+							</div>
+						</div>
+					</div>
+				</div>
+				<form action='/backend/create-checkout-session' method='POST' className='w-full sm:order-first sm:w-3/5'>
+					<p className='mb-6 text-xl sm:text-3xl'>
+						注文フォーム
+					</p>
+					<div className='mt-4'>
+						<label>メールアドレス<span className='text-amber-600'>*</span></label>
+						<input onChange={handleChange} name='email' type='email' className='w-full p-2 border rounded invalid:border-amber-600' value={customerData.email} required />
+					</div>
+					<p className='mt-6 text-lg sm:text-2xl'>配達</p>
+					<div className='mt-4'>
+						<label>氏名<span className='text-amber-600'>*</span></label>
+						<input onChange={handleChange} name='name' type='text' className='w-full p-2 border rounded invalid:border-amber-600' value={customerData.name} required />
+					</div>
+					<div className='mt-4 sm:flex gap-2'>
+						<div className='w-full'>
+							<label>郵便番号（半角数字7桁）<span className='text-amber-600'>*</span></label>
+							<input onChange={handleChange} name='zipCode' type='text' pattern="\d{7}" className='w-full p-2 border rounded invalid:border-amber-600' value={customerData.zipCode} required />
+						</div>
+						<div className='w-full'>
+							<label>都道府県<span className='text-amber-600'>*</span></label>
+							<select
+								onChange={handleAreaChange}
+								className='w-full h-10 bg-gray-50 border rounded invalid:border-amber-600'
+								value={customerData.prefecture}
+								required>
+								<option value="">選択してください</option>
+								<option value="北海道">北海道</option>
+								<option value="青森県">青森県</option>
+								<option value="岩手県">岩手県</option>
+								<option value="宮城県">宮城県</option>
+								<option value="秋田県">秋田県</option>
+								<option value="山形県">山形県</option>
+								<option value="福島県">福島県</option>
+								<option value="茨城県">茨城県</option>
+								<option value="栃木県">栃木県</option>
+								<option value="群馬県">群馬県</option>
+								<option value="埼玉県">埼玉県</option>
+								<option value="千葉県">千葉県</option>
+								<option value="東京都">東京都</option>
+								<option value="神奈川県">神奈川県</option>
+								<option value="新潟県">新潟県</option>
+								<option value="富山県">富山県</option>
+								<option value="石川県">石川県</option>
+								<option value="福井県">福井県</option>
+								<option value="山梨県">山梨県</option>
+								<option value="長野県">長野県</option>
+								<option value="岐阜県">岐阜県</option>
+								<option value="静岡県">静岡県</option>
+								<option value="愛知県">愛知県</option>
+								<option value="三重県">三重県</option>
+								<option value="滋賀県">滋賀県</option>
+								<option value="京都府">京都府</option>
+								<option value="大阪府">大阪府</option>
+								<option value="兵庫県">兵庫県</option>
+								<option value="奈良県">奈良県</option>
+								<option value="和歌山県">和歌山県</option>
+								<option value="鳥取県">鳥取県</option>
+								<option value="島根県">島根県</option>
+								<option value="岡山県">岡山県</option>
+								<option value="広島県">広島県</option>
+								<option value="山口県">山口県</option>
+								<option value="徳島県">徳島県</option>
+								<option value="香川県">香川県</option>
+								<option value="愛媛県">愛媛県</option>
+								<option value="高知県">高知県</option>
+								<option value="福岡県">福岡県</option>
+								<option value="佐賀県">佐賀県</option>
+								<option value="長崎県">長崎県</option>
+								<option value="熊本県">熊本県</option>
+								<option value="大分県">大分県</option>
+								<option value="宮崎県">宮崎県</option>
+								<option value="鹿児島県">鹿児島県</option>
+								<option value="沖縄県">沖縄県</option>
+							</select>
+						</div>
+					</div>
+					<div className='mt-4'>
+						<label>市区町村<span className='text-amber-600'>*</span></label>
+						<input onChange={handleChange} name='address' type='text' className='w-full p-2 border rounded invalid:border-amber-600' value={customerData.address} required />
+					</div>
+					<div className='mt-4'>
+						<label>電話番号（半角数字11桁）<span className='text-amber-600'>*</span></label>
+						<input onChange={handleChange} name='phone' type='tel' pattern="\d{11}" className='w-full p-2 border rounded invalid:border-amber-600' value={customerData.phone} required />
+					</div>
+					<p className='mt-6 text-lg sm:text-2xl'>備考欄</p>
+					<textarea onChange={handleChange} name='memo' className='mt-4 h-40 w-full p-2 border rounded' />
+					<input type="hidden" name="customerData" value={customerData} />
+					<button
+						type='submit'
+						className='w-full mt-6 p-2 text-center text-white bg-amber-600 hover:bg-amber-500 rounded'>
+						決済へすすむ
+					</button>
+				</form>
+			</div>
+		</div>
+	);
+};
+
+export default OrderForm;

--- a/frontend/src/pages/OrderProcessing.jsx
+++ b/frontend/src/pages/OrderProcessing.jsx
@@ -12,7 +12,7 @@ const OrderProcessing = () => {
 		const process = async () => {
 			console.log("OrderProcessingPage");
 			console.log("checkout_session_id: " + checkout_session_id);
-			await axios.post('/backend/order-process', {checkout_session_id: checkout_session_id})
+			await axios.post('/backend/order-process', {checkout_session_id})
 			.then((res) => res.data)
 			.then((data) => {
 				console.log(data.status);

--- a/frontend/src/pages/Product.jsx
+++ b/frontend/src/pages/Product.jsx
@@ -77,9 +77,9 @@ const Product = () => {
 			localStorage.setItem('cart', JSON.stringify([]));
 	}, [])
 
-	const Modal = () => {
+	const ShippingModal = () => {
 		const areaList = [
-			{method_name: 'Hokkaido', name: '北海道', prefectures: ''},
+			{method_name: 'Hokkaido', name: '北海道', prefectures: '北海道'},
 			{method_name: 'Hokkaido', name: '東北', prefectures: '青森県, 岩手県, 宮城県, 秋田県, 山形県, 福島県'},
 			{method_name: 'Hokkaido', name: '関東', prefectures: '茨城県, 栃木県, 群馬県, 埼玉県, 千葉県, 東京都, 神奈川県, 山梨県'},
 			{method_name: 'Hokkaido', name: '信越', prefectures: '新潟県, 長野県'},
@@ -89,7 +89,7 @@ const Product = () => {
 			{method_name: 'Hokkaido', name: '中国', prefectures: '鳥取県, 島根県, 岡山県, 広島県, 山口県'},
 			{method_name: 'Hokkaido', name: '四国', prefectures: '徳島県, 香川県, 愛媛県, 高知県'},
 			{method_name: 'Hokkaido', name: '九州', prefectures: '福岡県, 佐賀県, 長崎県, 熊本県, 大分県, 宮崎県, 鹿児島県'},
-			{method_name: 'Hokkaido', name: '沖縄', prefectures: ''},
+			{method_name: 'Hokkaido', name: '沖縄', prefectures: '沖縄県'},
 		];
 		if (shippingMethod.length) {
 			return (
@@ -135,7 +135,7 @@ const Product = () => {
 
 	return (
 		<div className='w-3/4 my-16 mx-auto'>
-			<Modal />
+			<ShippingModal />
 			<Toast isVisible={isVisible} setIsVisible={setIsVisible} />
 			<p className='mt-32 mb-10 sm:mt-40 sm:mb-20 text-center text-xl sm:text-4xl'>
 				{product.name}

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -2,6 +2,7 @@ export { default as About } from './About';
 export { default as Cart } from './Cart';
 export { default as FAQ } from './FAQ';
 export { default as OrderCompleted } from './OrderCompleted';
+export { default as OrderForm } from './OrderForm';
 export { default as OrderProcessing } from './OrderProcessing';
 export { default as Product } from './Product';
 export { default as Products } from './Products';


### PR DESCRIPTION
#26 

- backend
  - '/shipping/:id' ->返すデータをmin_n順に変更した
  - '/create-checkout-session'
    - stripe API 全体をコメントアウト
    - stripe 決済画面にて電話番号と住所を収集する設定を削除
    - stripe 決済の success_url リダイレクトではなく、{status: 'success', order_id: '0123456789'} のjsonオブジェクトを返す挙動に変更
- frontend
  - order-form ページを追加
  - pages/Cart.jsx の CreateCart()
    - src/functions に移動
    - 引数をsetCartに
    - cartStorageを引数で受け取らず、関数内で定義
  - Cartページのボタンを押して、order-formページに飛べるように
  - footer の copyright のマーク表記を変更
  - コード改善
    - pages/OrderProcessing.jsx: axios で渡すデータ
    - pages/OrderProcessing.jsx: モーダル名